### PR TITLE
Rely on hobo deps:chef to install berkshelf deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tools/chef/tmp/*
 tools/assets/*
 bin/*
 .DS_Store
+secret.key
 
 # Composer
 vendor

--- a/tools/chef/environments/development.json
+++ b/tools/chef/environments/development.json
@@ -4,6 +4,5 @@
   "json_class": "Chef::Environment",
   "chef_type": "environment",
   "default_attributes": {},
-  "override_attributes": {},
-  "run_list": []
+  "override_attributes": {}
 }

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -15,7 +15,6 @@ end
 Vagrant.require_plugin "vagrant-hostsupdater"
 Vagrant.require_plugin "vagrant-omnibus"
 Vagrant.require_plugin "vagrant-cachier"
-Vagrant.require_plugin "vagrant-berkshelf"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -37,10 +36,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # vagrant-cachier settings
   config.cache.auto_detect = true
 
-  # Berkshelf
-  config.berkshelf.enabled = true
-  config.berkshelf.berksfile_path = "../chef/Berksfile"
-
   # Shared folders
   require 'ffi'
   config.vm.synced_folder "../../", "/vagrant", :nfs => ! FFI::Platform::IS_WINDOWS
@@ -56,6 +51,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provision :chef_solo do |chef|
+    # Do not add site-cookbooks to this
+    # Berkshelf will copy any site-cookbooks defined in the Berksfile
+    chef.cookbooks_path = "../chef/cookbooks"
     chef.environments_path = "../chef/environments"
     chef.roles_path = "../chef/roles"
     chef.data_bags_path = "../chef/data_bags"


### PR DESCRIPTION
We're removing dependency on vagrant-berkshelf because it is now deprecated and has issues installing alongside vagrant-librarian-chef.

Given that vagrant-librarian-chef also has issues on windows (ffi compat issues with Vagrant omnibus ruby) the recommended method will now be to let hobo handle the chef deps (or do it manually if hobo is not in use).
