### PR TITLE
Create the capistrano shared folders that contain linked_files

### DIFF
--- a/tools/capistrano/lib/inviqa_cap/linked.rb
+++ b/tools/capistrano/lib/inviqa_cap/linked.rb
@@ -12,6 +12,10 @@ module InviqaCap
 
         namespace :inviqa do
           task :setup do
+            (linked_files || []).each do |file|
+              run "mkdir -p #{File.join(shared_path, File.dirname(file))}"
+            end
+
             (linked_directories || []).each do |file|
               run "mkdir -p #{File.join(shared_path, file)}"
             end


### PR DESCRIPTION
These folders are not linked to the release, but instead
are needed for the files to be createable.

Once merged, hobo-seed-default will need to be merged into the other seeds
