### PR TITLE
Updates data-bag-merge to 0.2.3

### DIFF
--- a/tools/chef/Berksfile
+++ b/tools/chef/Berksfile
@@ -12,7 +12,7 @@ cookbook 'memcached', '~> 1.7.2'
 cookbook 'nginx', '2.4.2'
 cookbook 'apache2', '~> 1.8.14'
 cookbook 'elasticsearch', '~> 0.3.7'
-cookbook 'data-bag-merge', '~> 0.1.3'
+cookbook 'data-bag-merge', '~> 0.2.3'
 
 cookbook 'jetty', :github => 'inviqa/chef-jetty', :tag => '0.2'
 cookbook 'solr', :github => 'inviqa/chef-solr', :tag => '1.0.1'

--- a/tools/chef/Berksfile.lock
+++ b/tools/chef/Berksfile.lock
@@ -8,7 +8,7 @@ DEPENDENCIES
     git: git://github.com/inviqa/chef-config-driven-helper.git
     revision: f92be8884aded673d0d6c788773af117a3899447
     ref: 1.3.0
-  data-bag-merge (~> 0.1.3)
+  data-bag-merge (~> 0.2.3)
   elasticsearch (~> 0.3.7)
   jetty
     git: git://github.com/inviqa/chef-jetty.git
@@ -55,7 +55,7 @@ GRAPH
     build-essential (>= 0.0.0)
     database (>= 0.0.0)
     mysql (>= 0.0.0)
-  data-bag-merge (0.1.3)
+  data-bag-merge (0.2.3)
   database (2.0.0)
     aws (>= 0.0.0)
     mysql (>= 1.3.0)

--- a/tools/chef/data_bags/environments/development.json
+++ b/tools/chef/data_bags/environments/development.json
@@ -1,17 +1,19 @@
 {
   "id": "development",
-  "mysql": {
-    "server_root_password": "984C42CF342f7j6",
-    "server_repl_password": "984C42CF342f7j6",
-    "server_debian_password": "984C42CF342f7j6",
-    "connections": {
-      "default": {
-        "password": "984C42CF342f7j6"
+  "default_attributes": {
+    "mysql": {
+      "server_root_password": "984C42CF342f7j6",
+      "server_repl_password": "984C42CF342f7j6",
+      "server_debian_password": "984C42CF342f7j6",
+      "connections": {
+        "default": {
+          "password": "984C42CF342f7j6"
+        }
       }
+    },
+    "ssl_certs": {
+      "/etc/pki/tls/certs/cert.pem": "{{chef_ssl.cert}}",
+      "/etc/pki/tls/private/key.pem": "{{chef_ssl.key}}"
     }
-  },
-  "ssl_certs": {
-    "/etc/pki/tls/certs/cert.pem": "{{chef_ssl.cert}}",
-    "/etc/pki/tls/private/key.pem": "{{chef_ssl.key}}"
   }
 }


### PR DESCRIPTION
This updates the data-bag-merge cookbook pin to be 0.2.3.
Andy has made a few changes for the 0.2 release to enable leveraging attribute precedence in the merge process, hence the re-factoring of the data bag structure.
