### PR TITLE
Bind mysql to localhost by default.

### DIFF
--- a/tools/chef/environments/development.json
+++ b/tools/chef/environments/development.json
@@ -21,7 +21,8 @@
           "password": "{{name}}",
           "database_name": "{{name}}"
         }
-      }
+      },
+      "bind_address": "127.0.0.1"
     },
 
     "packages": [ "git" ]


### PR DESCRIPTION
This will allow people to use fancy GUIs (i.e. workbench or sequelpro) to connect via SSH into mysql in vm.
