### PR TITLE
Allow remote access to mysql on local VM, including root user.

### DIFF
--- a/tools/chef/environments/development.json
+++ b/tools/chef/environments/development.json
@@ -12,6 +12,15 @@
           "docroot": "/vagrant/public"
         }
       }
+    },
+
+    "mysql": {
+      "allow_remote_root": true,
+      "bind_address": "0.0.0.0"
+    },
+
+    "iptables-standard": {
+      "allowed_incoming_ports": {"mysql": "mysql"}
     }
   },
 


### PR DESCRIPTION
Vagrant host-only network will only allow the host to access the port
so shouldn't cause major security issues.

based on @elvetemedve 's work on https://github.com/inviqa/hobo-seed-default/pull/25
