### PR TITLE
Update specs to match the right httpd vhost filename

### DIFF
--- a/tools/vagrant/spec/httpd_spec.rb
+++ b/tools/vagrant/spec/httpd_spec.rb
@@ -14,7 +14,7 @@ describe port(80) do
   it { should be_listening }
 end
 
-describe file('/etc/nginx/sites-enabled/{{hostname}}') do
+describe file('/etc/nginx/sites-enabled/{{name}}') do
   it { should be_file }
   its(:content) { should match /server_name .*{{hostname}}.*/ }
 end


### PR DESCRIPTION
Reapply the VM spec fixes as a single commit, and remove the incorrect servername change, as this is meant to be the hostname, not name
