### PR TITLE
Allow remote access to mysql on local VM, including root user.

### DIFF
--- a/tools/chef/environments/development.json
+++ b/tools/chef/environments/development.json
@@ -21,6 +21,15 @@
           "database_name": "{{name}}"
         }
       }
+    },
+
+    "mysql": {
+      "allow_remote_root": true,
+      "bind_address": "0.0.0.0"
+    },
+
+    "iptables-standard": {
+      "allowed_incoming_ports": {"mysql": "mysql"}
     }
   },
 


### PR DESCRIPTION
Vagrant host-only network will only allow the host to access the port
so shouldn't cause major security issues.
