### PR TITLE
Remove config-driven-helper::packages call from web-apache role

### DIFF
--- a/tools/chef/roles/web-apache.json
+++ b/tools/chef/roles/web-apache.json
@@ -21,7 +21,6 @@
   },
   "run_list": [
     "recipe[apache2]",
-    "recipe[config-driven-helper::packages]",
     "recipe[config-driven-helper::services]",
     "recipe[config-driven-helper::apache-sites]"
   ]


### PR DESCRIPTION
No packages are configured, and it complains about needing to use packages-additional instead when under Chef 12+.