### PR TITLE
Add filter module to apache as this is used when mod_deflate is enabled

### DIFF
--- a/tools/chef/roles/web-apache.json
+++ b/tools/chef/roles/web-apache.json
@@ -7,6 +7,7 @@
     "apache": {
       "default_site_enabled": false,
       "default_modules": [
+        "mod_filter",
         "mod_php5",
         "mod_rewrite",
         "mod_ssl",


### PR DESCRIPTION
The apache vhost uses mod_filter's `AddOutputFilterByType` in https://github.com/inviqa/chef-config-driven-helper/blob/master/templates/default/apache_site.conf.erb#L103 which needs mod_filter under Apache 2.4.