### PR TITLE
Use delegated volume by default over docker-sync

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:inviqa/inviqa-rake-tasks-docker-sync.git
-  revision: 8d5fe8e73d9ef00d882021a9a8164fd63553d67e
+  revision: e1dae498988253ad5d9265bdeac8d5141b8640d2
   specs:
     rake-tasks-docker-sync (0.1.0)
       docker-sync
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: git@github.com:inviqa/inviqa-rake-tasks-docker.git
-  revision: d3d51a18638a3ad66147044bf09d3517b974434c
+  revision: f965ccdcff43cd3a9f23165b6f14e5dc0c4507ac
   ref: feature/more-tasks-to-avoid-make-tasks
   specs:
     rake-tasks-docker (0.2.0)
@@ -139,7 +139,7 @@ GEM
       cucumber-tag_expressions (>= 1.0.1)
       gherkin (>= 4.1.3)
     cucumber-tag_expressions (1.0.1)
-    daemons (1.2.5)
+    daemons (1.2.6)
     diff-lcs (1.2.5)
     docker-compose (1.1.7)
       backticks (~> 1.0)

--- a/README.project.md.erb
+++ b/README.project.md.erb
@@ -34,10 +34,11 @@ git clone <%= config.git_url %>
 
 ##### MacOS
 
-Set up docker-sync to improve volume performance:
-```bash
-gem install docker-sync
-```
+By default we use docker for mac's delegated volume.
+There is the option of using `docker-sync` by specifying `RAKE_USE_DOCKER_SYNC=true` in your shell's environment variables.
+
+##### Linux
+Install Ruby 2.2.x if you don't have it installed and ensure that bundler is installed (`gem install bundler`).
 
 #### Setup
 


### PR DESCRIPTION
* On most Mac installs, a delegated volume gives better performance.
* On some Mac installs, docker-sync is preferable so users can opt for this via an environment variable