### PR TITLE
DEVOPS-551: Provide the CP environment domain as the WEB_HOST

### DIFF
--- a/continuous-pipe.yml.erb
+++ b/continuous-pipe.yml.erb
@@ -5,7 +5,9 @@ variables:
   CP_ENVIRONMENT:
     name: CP_ENVIRONMENT
     expression: '"<%= config.name %>-" ~ code_reference.branch'
-  CP_ENVIRONMENT_DOMAIN_SUFFIX: -<%= config.name %>.webpipeline.net
+  CP_ENVIRONMENT_DOMAIN:
+    name: CP_ENVIRONMENT_DOMAIN
+    expression: 'slugify(hash_long_domain_prefix(code_reference.branch, 39)) ~ "-<%= config.name %>.webpipeline.net"'
   SENDMAIL_RELAY_HOST:
     name: SENDMAIL_RELAY_HOST
     expression: '"mailcatcher.<%= config.name %>-" ~ slugify(code_reference.branch) ~ ".svc.cluster.local"'
@@ -158,10 +160,12 @@ tasks:
                     email: ${CLOUD_FLARE_EMAIL?:}
                     api_key: ${CLOUD_FLARE_API_KEY?:}
                 proxied: true
-                record_suffix: ${CP_ENVIRONMENT_DOMAIN_SUFFIX}
+                host:
+                  expression: '"${CP_ENVIRONMENT_DOMAIN}"'
               ingress:
                 class: nginx
-                host_suffix: ${CP_ENVIRONMENT_DOMAIN_SUFFIX}
+                host:
+                  expression: '"${CP_ENVIRONMENT_DOMAIN}"'
           specification:
             source:
               image: continuouspipe/landing-page
@@ -201,6 +205,7 @@ tasks:
               TRUSTED_REVERSE_PROXIES: ${TRUSTED_REVERSE_PROXIES?:}
               TIDEWAYS_API_KEY: ${TIDEWAYS_API_KEY?:}
               SENDMAIL_RELAY_HOST: ${SENDMAIL_RELAY_HOST}
+              WEB_HOST: ${CP_ENVIRONMENT_DOMAIN}
 
             resources:
               requests:

--- a/continuous-pipe.yml.erb
+++ b/continuous-pipe.yml.erb
@@ -7,7 +7,8 @@ variables:
     expression: '"<%= config.name %>-" ~ code_reference.branch'
   CP_ENVIRONMENT_DOMAIN:
     name: CP_ENVIRONMENT_DOMAIN
-    expression: 'slugify(hash_long_domain_prefix(code_reference.branch, 39)) ~ "-<%= config.name %>.webpipeline.net"'
+    # construct a domain from the branch no longer than 64 characters
+    expression: 'slugify(hash_long_domain_prefix(code_reference.branch, 64 - <%= "-#{config.name}.webpipeline.net".length %>)) ~ "-<%= config.name %>.webpipeline.net"'
   SENDMAIL_RELAY_HOST:
     name: SENDMAIL_RELAY_HOST
     expression: '"mailcatcher.<%= config.name %>-" ~ slugify(code_reference.branch) ~ ".svc.cluster.local"'


### PR DESCRIPTION
Used for things like self-signed certificate common name, and downstream seeds configuration

CP cloudflare settings changed to support the full domain in the process