### PR TITLE
DEVOPS-563 upgrade software

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/php7-nginx:stable
+FROM quay.io/continuouspipe/php7.2-nginx:stable
 
 ARG GITHUB_TOKEN=
 ARG ASSETS_S3_BUCKET=

--- a/tools/chef/roles/php72-development.json
+++ b/tools/chef/roles/php72-development.json
@@ -1,0 +1,16 @@
+{
+  "name": "php72-development",
+  "chef_type": "role",
+  "json_class": "Chef::Role",
+  "description": "PHP7.2 development role",
+  "override_attributes": {
+    "php": {
+      "packages": [
+        "php72w-pecl-xdebug"
+      ]
+    }
+  },
+  "run_list": [
+    "role[php72]"
+  ]
+}

--- a/tools/chef/roles/php72.json
+++ b/tools/chef/roles/php72.json
@@ -1,0 +1,34 @@
+{
+  "name": "php72",
+  "chef_type": "role",
+  "json_class": "Chef::Role",
+  "description": "PHP7.2 role",
+  "override_attributes": {
+    "php-fpm": {
+      "package_name": "php72w-fpm"
+    },
+    "php": {
+      "packages": [
+        "php72w",
+        "php72w-bcmath",
+        "php72w-devel",
+        "php72w-fpm",
+        "php72w-gd",
+        "php72w-mbstring",
+        "php72w-mysqlnd",
+        "php72w-opcache",
+        "php72w-pdo",
+        "php72w-pecl-apcu",
+        "php72w-pecl-imagick",
+        "php72w-pecl-redis",
+        "php72w-soap",
+        "php72w-xml",
+        "php72w-xmlrpc"
+      ]
+    }
+  },
+  "run_list": [
+    "yum-webtatic",
+    "php"
+  ]
+}

--- a/tools/chef/roles/redis30.json
+++ b/tools/chef/roles/redis30.json
@@ -19,6 +19,12 @@
           "port": "6379"
         }
       ]
+    },
+    "yum": {
+      "ius-archive": {
+        "enabled": true,
+        "managed": true
+      }
     }
   },
   "run_list": [

--- a/tools/chef/roles/redis32.json
+++ b/tools/chef/roles/redis32.json
@@ -1,0 +1,29 @@
+{
+  "name": "redis32",
+  "chef_type": "role",
+  "json_class": "Chef::Role",
+  "description": "Redis 3.2 server role",
+  "default_attributes": {
+    "redisio": {
+      "package_install": true,
+      "package_name": "redis32u",
+      "safe_install": false,
+      "default_settings": {
+        "loglevel": "warning",
+        "unixsocket": "/var/run/redis/master/redis.sock",
+        "unixsocketperm": "777"
+      },
+      "servers": [
+        {
+          "name": "master",
+          "port": "6379"
+        }
+      ]
+    }
+  },
+  "run_list": [
+    "recipe[yum-ius]",
+    "recipe[redisio]",
+    "recipe[redisio::enable]"
+  ]
+}


### PR DESCRIPTION
Provide updates for PHP to 7.2 and Redis to 3.2

Requires https://github.com/continuouspipe/dockerfiles/pull/460 to be merged and tagged stable for the docker image to be made available