### PR TITLE
Bump config-driven-helper to 3.0 for SSL cipher improvement defaults

### DIFF
--- a/tools/chef/Berksfile
+++ b/tools/chef/Berksfile
@@ -26,7 +26,7 @@ cookbook 'data-bag-merge', '~> 0.2.4'
 cookbook 'jetty', :github => 'inviqa/chef-jetty', :tag => '0.2'
 cookbook 'solr', :github => 'inviqa/chef-solr', :tag => '1.0.1'
 cookbook 'chef-varnish', :github => 'inviqa/chef-varnish', :ref => '2.1.0'
-cookbook 'config-driven-helper', '~> 2.5'
+cookbook 'config-driven-helper', '~> 3.0'
 cookbook 'iptables-patterns', '~> 0.1.0'
 cookbook 'php-fpm', '~> 0.7.5'
 

--- a/tools/chef/Berksfile.lock
+++ b/tools/chef/Berksfile.lock
@@ -4,7 +4,7 @@ DEPENDENCIES
     git: https://github.com/inviqa/chef-varnish.git
     revision: b75b32ef89ad339f1476ba2121017a0ef606feaa
     ref: 2.1.0
-  config-driven-helper (~> 2.5)
+  config-driven-helper (~> 3.0)
   data-bag-merge (~> 0.2.4)
   elasticsearch (~> 0.3.7)
   iptables-patterns (~> 0.1.0)
@@ -56,7 +56,7 @@ GRAPH
     yum (>= 0.0.0)
   chef_handler (1.4.0)
   compat_resource (12.10.7)
-  config-driven-helper (2.5.0)
+  config-driven-helper (3.0.0)
     apache2 (>= 1.8)
     build-essential (~> 1.4)
     database (~> 2.0.0)


### PR DESCRIPTION
Depends on https://github.com/inviqa/chef-config-driven-helper/pull/92 and https://github.com/inviqa/chef-config-driven-helper/pull/93 being released