### PR TITLE
Detect High Sierra and if found, use TCP for NFS instead of UDP.

### DIFF
--- a/tools/vagrant/Vagrantfile.erb
+++ b/tools/vagrant/Vagrantfile.erb
@@ -93,7 +93,7 @@ def mount_options
   nfs_version = 3
   nfs_version = 4 if FFI::Platform::IS_LINUX
   protocol = 'udp'
-  protocol = 'tcp' if nfs_version == 4
+  protocol = 'tcp' if nfs_version == 4 || is_high_sierra
   mount_options = { mount_options: ["dmode=777", "fmode=777"] }
   mount_options = {
     type: :nfs,
@@ -101,4 +101,10 @@ def mount_options
     mount_options: ['rw', "vers=#{nfs_version}", protocol, 'nolock', 'noatime', 'actimeo=1']
   } unless FFI::Platform::IS_WINDOWS
   mount_options
+end
+
+def is_high_sierra
+  return false unless FFI::Platform::IS_MAC
+  system("sw_vers | grep -q '10\.13'")
+  return $?.to_i > 0
 end

--- a/tools/vagrant/Vagrantfile.erb
+++ b/tools/vagrant/Vagrantfile.erb
@@ -93,7 +93,7 @@ def mount_options
   nfs_version = 3
   nfs_version = 4 if FFI::Platform::IS_LINUX
   protocol = 'udp'
-  protocol = 'tcp' if nfs_version == 4 || is_high_sierra
+  protocol = 'tcp' if nfs_version == 4 || is_high_sierra_or_newer
   mount_options = { mount_options: ["dmode=777", "fmode=777"] }
   mount_options = {
     type: :nfs,
@@ -103,8 +103,7 @@ def mount_options
   mount_options
 end
 
-def is_high_sierra
+def is_high_sierra_or_newer
   return false unless FFI::Platform::IS_MAC
-  system("sw_vers | grep -q '10\.13'")
-  return $?.to_i > 0
+  return Gem::Dependency.new('', '~> 10.13').match?('', `sw_vers -productVersion`)
 end


### PR DESCRIPTION
Simply could not get NFS mountpoints on High Sierra and Vagrant 2.0.3 working without forcing it to use TCP.