### PR TITLE
Split seed builds across nodes in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,6 +76,7 @@ EOF
                         }
                     }
                     steps {
+                        deleteDir()
                         unstash 'planted'
                         sh 'eval "$(ssh-agent)" && ssh-add && hem vm rebuild'
                         sh 'hem exec bash -c \'cd tools/vagrant && rake\''
@@ -94,6 +95,7 @@ EOF
                         }
                     }
                     steps {
+                        deleteDir()
                         unstash 'planted'
                         sh 'hem deps gems'
                         sh 'hem exec bash -c \'rake docker:up\''
@@ -112,6 +114,7 @@ EOF
                         }
                     }
                     steps {
+                        deleteDir()
                         unstash 'planted'
                         sh 'sed -i -E "s#(quay.io/continuouspipe/[^:]*:)stable(\\s*)#\\1latest\\2#g" Dockerfile docker-compose.yml'
                         sh 'hem deps gems'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,10 @@ pipeline {
         cron cron_string
     }
 
+    environment {
+        COMPOSE_HTTP_TIMEOUT = 600
+    }
+
     options {
         buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '5'))
         disableConcurrentBuilds()
@@ -97,7 +101,7 @@ EOF
                     steps {
                         deleteDir()
                         unstash 'planted'
-                        sh 'hem deps gems'
+                        sh 'docker-compose pull'
                         sh 'hem exec bash -c \'rake docker:up\''
                     }
                     post {
@@ -117,7 +121,7 @@ EOF
                         deleteDir()
                         unstash 'planted'
                         sh 'sed -i -E "s#(quay.io/continuouspipe/[^:]*:)stable(\\s*)#\\1latest\\2#g" Dockerfile docker-compose.yml'
-                        sh 'hem deps gems'
+                        sh 'docker-compose pull'
                         sh 'hem exec bash -c \'rake docker:up\''
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,10 @@
 String cron_string = BRANCH_NAME == 'master' ? 'H H * * *' : ''
 
+def GetWorkspace(suffix = '')
+{
+    return 'workspace/' + env.BUILD_TAG.replace('%', '-') + suffix;
+}
+
 pipeline {
     agent none
 
@@ -67,7 +72,7 @@ EOF
                     agent {
                         node {
                             label 'vmbuild'
-                            customWorkspace "workspace/${BUILD_TAG}@vm"
+                            customWorkspace GetWorkspace('@vm')
                         }
                     }
                     steps {
@@ -85,7 +90,7 @@ EOF
                     agent {
                         node {
                             label 'dockerbuild'
-                            customWorkspace "workspace/${BUILD_TAG}@stable"
+                            customWorkspace GetWorkspace('@stable')
                         }
                     }
                     steps {
@@ -103,7 +108,7 @@ EOF
                     agent {
                         node {
                             label 'dockerbuild'
-                            customWorkspace "workspace/${BUILD_TAG}@latest"
+                            customWorkspace GetWorkspace('@latest')
                         }
                     }
                     steps {


### PR DESCRIPTION
Rather than run vagrant and the two docker builds in parallel on the same node alongside other docker builds, take up the `dockerbuild` executors.

The advantage of this is that it scales if we add more Jenkins workers.

In addition, letting Jenkins know about the different directories being used should let it handle cleanup if we install plugins/configure it.